### PR TITLE
[DPE-6748] Add MM implementation

### DIFF
--- a/examples/mirrormaker.py
+++ b/examples/mirrormaker.py
@@ -25,6 +25,7 @@ class MirrormakerConfigFormatter(BaseConfigFormatter):
         json_key="topics.exclude",
         default=".*[-.]internal,.*.replica,__.*,.*-config,.*-status,.*-offset",
     )
+    tasks_max = ConfigOption(json_key="tasks.max", default=1, configurable=True)
 
     # non-configurable options
     clusters = ConfigOption(json_key="clusters", default="source,target", configurable=False)
@@ -34,12 +35,7 @@ class MirrormakerConfigFormatter(BaseConfigFormatter):
     target_cluster_alias = ConfigOption(
         json_key="target.cluster.alias", default="target", configurable=False
     )
-
-    tasks_max = ConfigOption(json_key="tasks.max", default=1, configurable=False)
     auto_create = ConfigOption(json_key="auto.create", default=True, configurable=False)
-    sync_topic_acls = ConfigOption(
-        json_key="sync.topic.acls.enabled", default=False, configurable=False
-    )
     emit_heartbeats = ConfigOption(
         json_key="emit.heartbeats.enabled", default=True, configurable=False
     )
@@ -54,7 +50,6 @@ class MirrormakerConfigFormatter(BaseConfigFormatter):
         description="Whether to prefix the replicated topics with the alias of the source cluster or not.",
         mode="none",
     )
-    topic_name = ConfigOption(json_key="na", default="test_topic", mode="none")
 
 
 class Integrator(BaseIntegrator):
@@ -72,7 +67,8 @@ class Integrator(BaseIntegrator):
         super().__init__(charm, plugin_server_args, plugin_server_kwargs)
         self.name = charm.app.name
         self.prefix_topics = bool(self.charm.config.get("prefix_topics", False))
-        self.topic_name = str(self.charm.config.get("topic_name", "test_topic"))
+        # Not used, but required by the Kafka relation. Will create an ACL on Kafka
+        self.topic_name = "__mirrormaker-user"
 
         self.source_requirer_data = KafkaRequirerData(
             model=self.model,
@@ -101,20 +97,47 @@ class Integrator(BaseIntegrator):
                 "replication.policy.class": "org.apache.kafka.connect.mirror.IdentityReplicationPolicy"
             }
 
-        self.configure(
+        common_auth = {
+            "source.cluster.bootstrap.servers": source_data.get("endpoints"),
+            "target.cluster.bootstrap.servers": target_data.get("endpoints"),
+            "source.cluster.security.protocol": "SASL_PLAINTEXT",
+            "source.cluster.sasl.mechanism": "SCRAM-SHA-512",
+            "source.cluster.sasl.jaas.config": f"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{source_data.get('username')}\" password=\"{source_data.get('password')}\";",
+            "target.cluster.security.protocol": "SASL_PLAINTEXT",
+            "target.cluster.sasl.mechanism": "SCRAM-SHA-512",
+            "target.cluster.sasl.jaas.config": f"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{target_data.get('username')}\" password=\"{target_data.get('password')}\";",
+        }
+
+        mirror_source = (
             {
+                "name": "source",
                 "connector.class": "org.apache.kafka.connect.mirror.MirrorSourceConnector",
-                "source.cluster.bootstrap.servers": source_data.get("endpoints"),
-                "target.cluster.bootstrap.servers": target_data.get("endpoints"),
-                "source.cluster.security.protocol": "SASL_PLAINTEXT",
-                "source.cluster.sasl.mechanism": "SCRAM-SHA-512",
-                "source.cluster.sasl.jaas.config": f"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{source_data.get('username')}\" password=\"{source_data.get('password')}\";",
-                "target.cluster.security.protocol": "SASL_PLAINTEXT",
-                "target.cluster.sasl.mechanism": "SCRAM-SHA-512",
-                "target.cluster.sasl.jaas.config": f"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{target_data.get('username')}\" password=\"{target_data.get('password')}\";",
+                "refresh.topics.enabled": True,
+                "refresh.topics.interval.seconds": 5,
+                "sync.topic.acls.enabled": True,
             }
             | prefix_policy
+            | common_auth
         )
+
+        # TODO: to add?
+        # "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        # "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        # "groups.exclude": "console-consumer-.*, connect-.*, __.*",
+        # ^ making this last one configurable by users might be a pain
+        # mirror_checkpoint = {
+        #     "name": "checkpoint",
+        #     "connector.class": "org.apache.kafka.connect.mirror.MirrorCheckpointConnector",
+        #     "consumer.auto.offset.reset": "earliest",
+        #     "refresh.groups.enabled": True,
+        #     "refresh.groups.interval.seconds": 5,
+        #     "sync.group.offsets.interval.seconds": 5,
+        #     "producer.linger.ms": 500,
+        #     "producer.retry.backoff.ms": 1000,
+        #     "producer.max.block.ms": 10000,
+        # } | prefix_policy | common_auth
+
+        self.configure([mirror_source])
 
     @override
     def teardown(self):

--- a/examples/mirrormaker.py
+++ b/examples/mirrormaker.py
@@ -115,9 +115,18 @@ class Integrator(BaseIntegrator):
             {
                 "name": "source",
                 "connector.class": "org.apache.kafka.connect.mirror.MirrorSourceConnector",
+                "sync.topic.acls.enabled": True,
+                "sync.topic.configs.enabled": True,
+                "sync.topic.configs.interval.seconds": 5,
                 "refresh.topics.enabled": True,
                 "refresh.topics.interval.seconds": 5,
-                "sync.topic.acls.enabled": True,
+                "refresh.groups.enabled": True,
+                "refresh.groups.interval.seconds": 10,
+                "groups.exclude": "console-consumer-.*,connect-.*,__.*",
+                "consumer.auto.offset.reset": "earliest",
+                "producer.max.block.ms": 10000,
+                "producer.linger.ms": 500,
+                "producer.retry.backoff.ms": 1000,
             }
             | prefix_policy
             | common_auth

--- a/examples/mirrormaker.py
+++ b/examples/mirrormaker.py
@@ -111,8 +111,9 @@ class Integrator(BaseIntegrator):
                 "source.cluster.sasl.jaas.config": f"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{source_data.get('username')}\" password=\"{source_data.get('password')}\";",
                 "target.cluster.security.protocol": "SASL_PLAINTEXT",
                 "target.cluster.sasl.mechanism": "SCRAM-SHA-512",
-                "target.cluster.sasl.jaas.config": f"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{target_data.get('username')}\" password=\"{target_data.get('password')}D\";",
-            } | prefix_policy
+                "target.cluster.sasl.jaas.config": f"org.apache.kafka.common.security.scram.ScramLoginModule required username=\"{target_data.get('username')}\" password=\"{target_data.get('password')}\";",
+            }
+            | prefix_policy
         )
 
     @override

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -461,6 +461,14 @@ class _DataInterfacesHelpers:
     def __init__(self, charm: CharmBase):
         self.charm = charm
 
+    def remote_app_name(self, relation_name: str) -> str:
+        """Returns the remote application name for the given relation name."""
+        relation = self.charm.model.get_relation(relation_name=relation_name)
+        if not relation:
+            return ""
+
+        return relation.app.name
+
     def fetch_all_relation_data(self, relation_name: str) -> MutableMapping:
         """Returns a MutableMapping of all relation data available to the unit on `relation_name`, either via databag or secrets."""
         relation = self.charm.model.get_relation(relation_name=relation_name)

--- a/lib/charms/kafka_connect/v0/integrator.py
+++ b/lib/charms/kafka_connect/v0/integrator.py
@@ -392,6 +392,9 @@ class ConnectClient:
         )
 
         if response.status_code == 200:
+            logger.debug(
+                f"Connector {connector_name or self.connector_name} patched: {connector_config}"
+            )
             return
 
         logger.error(response.content)
@@ -708,7 +711,7 @@ class BaseIntegrator(ABC, Object):
             try:
                 self._client.start_connector(
                     connector_config=self.formatter.to_dict(
-                        charm_config=self.config, mode="source"
+                        charm_config=self.config, mode=self.mode
                     )
                     | self.dynamic_config[connector_name],
                     connector_name=connector_name,
@@ -721,7 +724,7 @@ class BaseIntegrator(ABC, Object):
         if not self.connector_names:
             try:
                 self._client.start_connector(
-                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    self.formatter.to_dict(charm_config=self.config, mode=self.mode)
                     | self.dynamic_config
                 )
             except ConnectApiError as e:
@@ -758,7 +761,7 @@ class BaseIntegrator(ABC, Object):
             try:
                 self._client.patch_connector(
                     connector_config=self.formatter.to_dict(
-                        charm_config=self.config, mode="source"
+                        charm_config=self.config, mode=self.mode
                     )
                     | self.dynamic_config[connector_name],
                     connector_name=connector_name,
@@ -771,7 +774,7 @@ class BaseIntegrator(ABC, Object):
         if not self.connector_names:
             try:
                 self._client.patch_connector(
-                    self.formatter.to_dict(charm_config=self.config, mode="source")
+                    self.formatter.to_dict(charm_config=self.config, mode=self.mode)
                     | self.dynamic_config
                 )
             except ConnectApiError as e:

--- a/metadata.yaml.j2
+++ b/metadata.yaml.j2
@@ -29,10 +29,19 @@ requires:
     interface: connect_client
     optional: true
     limit: 1
+{% if data_interface != 'kafka_client' %}
   data:
     interface: {{ data_interface }}
     optional: true
     limit: 1
+{% else %}
+  source:
+    interface: {{ data_interface }}
+    limit: 1
+  target:
+    interface: {{ data_interface }}
+    limit: 1
+{% endif %}
 
 resources:
   connect-plugin:

--- a/src/charm.py
+++ b/src/charm.py
@@ -84,6 +84,7 @@ class IntegratorCharm(CharmBase):
 
         # NOTE: When publishing MirrorMaker integrator to CH, ensure to publish with an empty.tar so as not to break here
         if self.integrator.server.plugin_url == PLUGIN_URL_NOT_REQUIRED:
+            self.integrator.patch_connector()
             return
 
         resource_path = None


### PR DESCRIPTION
~Implementation of single connector (MirrorSource). Will be followed by adding the other 2 connectors needed for a fully working MM2.0. (Hearbeats and Checkpoint connectors)~

- Add configurations for MirrorSourceConnector and MirrorCheckpointConnector
- Config option `prefix_topics` is used to determine if the topics from source -> target will be called the same on both or they will be called `source.<topic>` on the target cluster.

NOTE: No need to review `integrator.py` as is just a copy from https://github.com/canonical/kafka-connect-operator/pull/22