### PR TITLE
[DPE-6895] Add active-active tests

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -149,6 +149,7 @@ async def assert_messages_produced(
     topic: str = "test",
     no_messages: int = 1,
     consumer_group: str | None = None,
+    pattern: str | None = None,
 ) -> None:
     """Asserts `no_messages` has been produced to `topic`."""
     username = "admin"
@@ -168,6 +169,8 @@ async def assert_messages_produced(
             consumer_timeout_ms=5000,
             group_id=consumer_group,
         )
+        if pattern:
+            consumer.subscribe(pattern=pattern)
 
         for msg in consumer:
             messages.append(msg.value)

--- a/tests/integration/test_mirrormaker.py
+++ b/tests/integration/test_mirrormaker.py
@@ -4,13 +4,16 @@
 
 import asyncio
 import logging
+from subprocess import PIPE, check_output
 
 import pytest
 from helpers import (
     CONNECT_APP,
+    CONNECT_CHANNEL,
     KAFKA_APP,
     KAFKA_APP_B,
     assert_messages_produced,
+    cleanup_mm_topics,
     produce_messages,
 )
 from pytest_operator.plugin import OpsTest
@@ -18,11 +21,17 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 MM_APP = "mirrormaker"
-PRODUCER_APP = "producer"
+
+# Used for active-active tests
+MM_APP_B = "mirrormaker-b"
+CONNECT_APP_B = "kafka-connect-b"
 
 
 # Deployment with KAFKA A and KAFKA B. These two charms will be used to test active-passive and
 # active-active replication. Kafka A will also be used as connect backend.
+
+
+# ----------- ACTIVE-PASSIVE TESTS -----------
 
 
 @pytest.mark.abort_on_fail
@@ -95,7 +104,7 @@ async def test_relate_with_connect_starts_integrator(ops_test: OpsTest):
 async def test_consume_messages_on_passive_cluster(ops_test: OpsTest):
     """Produce messages to a Kafka topic."""
     # Give some time for the messages to be replicated
-    await asyncio.sleep(120)
+    await asyncio.sleep(10)
 
     # Check that the messages can be consumed on the passive cluster
     await assert_messages_produced(ops_test, KAFKA_APP_B, topic="arnor", no_messages=100)
@@ -119,4 +128,105 @@ async def test_consumer_groups(ops_test: OpsTest):
     # using the same consumer group
     await assert_messages_produced(
         ops_test, KAFKA_APP_B, topic="arnor", no_messages=40, consumer_group="arnor-1"
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_relation(ops_test: OpsTest):
+    """Remove mm relation and check that messages are not replicated anymore."""
+    check_output(
+        f"JUJU_MODEL={ops_test.model_full_name} juju remove-relation {MM_APP} {CONNECT_APP}",
+        stderr=PIPE,
+        shell=True,
+        universal_newlines=True,
+    )
+
+    await ops_test.model.wait_for_idle(apps=[MM_APP, CONNECT_APP], idle_period=30, timeout=600)
+
+    # Check that the messages are not replicated anymore
+    await produce_messages(ops_test, KAFKA_APP, topic="angmar", no_messages=100)
+
+    await asyncio.sleep(10)
+
+    # Check that the messages are not replicated on the passive cluster
+    await assert_messages_produced(ops_test, KAFKA_APP_B, topic="angmar", no_messages=0)
+
+    # Reset state for next tests
+    await cleanup_mm_topics(ops_test, kafka_apps=[KAFKA_APP_B], extra_topics=["arnor"])
+
+
+# ----------- ACTIVE-ACTIVE TESTS -----------
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_active_active(ops_test: OpsTest, substrate, app_charm):
+    """Deploys active-active scenario."""
+    mm_config = {"prefix_topics": "true"}
+    await ops_test.model.deploy(
+        app_charm.charm,
+        application_name=MM_APP_B,
+        resources={**app_charm.resources},
+        config=mm_config,
+    )
+
+    await ops_test.model.deploy(
+        "kafka-connect" if substrate == "vm" else "kafka-connect-k8s",
+        channel=CONNECT_CHANNEL,
+        application_name=CONNECT_APP_B,
+        num_units=1,
+    )
+    # Initial mirrormaker integratior also needs to use prefixes now
+    await ops_test.model.applications[MM_APP].set_config(mm_config)
+
+    # This second deployment of mirrormaker will switch the relation and use KAFKA_APP_B as source
+    # This connect instance will use the passive (now KAFKA_APP) end as it's backend
+    await ops_test.model.integrate(CONNECT_APP_B, KAFKA_APP)
+    await ops_test.model.integrate(f"{MM_APP_B}:source", KAFKA_APP_B)
+    await ops_test.model.integrate(f"{MM_APP_B}:target", KAFKA_APP)
+
+    async with ops_test.fast_forward(fast_interval="60s"):
+        await ops_test.model.wait_for_idle(
+            apps=[CONNECT_APP_B, MM_APP_B, KAFKA_APP, KAFKA_APP_B], idle_period=30, timeout=600
+        )
+
+    # should still be in blocked mode because it needs kafka-connect relation
+    assert ops_test.model.applications[MM_APP_B].status == "blocked"
+
+
+@pytest.mark.abort_on_fail
+async def test_activate_integrator_active_active(ops_test: OpsTest):
+    """Checks integrator becomes active after related with active and passive ends of Kafka."""
+    await ops_test.model.integrate(MM_APP, CONNECT_APP)
+    await ops_test.model.integrate(MM_APP_B, CONNECT_APP_B)
+
+    logging.info("Sleeping...")
+    async with ops_test.fast_forward(fast_interval="20s"):
+        await ops_test.model.wait_for_idle(
+            apps=[MM_APP, CONNECT_APP, MM_APP_B, CONNECT_APP_B],
+            idle_period=60,
+            timeout=600,
+            status="active",
+        )
+
+    # test task is running
+    assert "RUNNING" in ops_test.model.applications[MM_APP].status_message
+    assert "RUNNING" in ops_test.model.applications[MM_APP_B].status_message
+
+
+@pytest.mark.abort_on_fail
+async def test_messages_on_both_active_cluster(ops_test: OpsTest):
+    """Produce messages to a Kafka topic."""
+    await produce_messages(ops_test, KAFKA_APP, topic="arnor", no_messages=100)
+    await produce_messages(ops_test, KAFKA_APP_B, topic="arnor", no_messages=100)
+    logging.info("100 messages produced to topic arnor")
+
+    # Give some time for the messages to be replicated
+    await asyncio.sleep(20)
+
+    # Check that the messages can be consumed on the passive cluster
+    await assert_messages_produced(
+        ops_test, KAFKA_APP, topic="kafka-b.replica.arnor", no_messages=100
+    )
+    await assert_messages_produced(
+        ops_test, KAFKA_APP_B, topic="kafka.replica.arnor", no_messages=100
     )

--- a/tests/integration/test_mirrormaker.py
+++ b/tests/integration/test_mirrormaker.py
@@ -208,12 +208,6 @@ async def test_activate_integrator_active_active(ops_test: OpsTest):
             status="active",
         )
 
-    # task is running
-    assert "RUNNING" in ops_test.model.applications[MM_APP].status_message
-    # Mirrormaker B shouldn't have any tasks running yet, meaning it's not replicating anything
-    # All the topics that exist on Kafka-B should be excluded from the replication
-    assert "UNASSIGNED" in ops_test.model.applications[MM_APP_B].status_message
-
 
 @pytest.mark.abort_on_fail
 async def test_messages_on_both_active_cluster(ops_test: OpsTest):
@@ -226,9 +220,5 @@ async def test_messages_on_both_active_cluster(ops_test: OpsTest):
     await asyncio.sleep(20)
 
     # Check that the messages can be consumed on the passive cluster
-    await assert_messages_produced(
-        ops_test, KAFKA_APP, topic="kafka-b.replica.fornost", no_messages=100
-    )
-    await assert_messages_produced(
-        ops_test, KAFKA_APP_B, topic="kafka.replica.fornost", no_messages=100
-    )
+    await assert_messages_produced(ops_test, KAFKA_APP, pattern=".*.fornost", no_messages=100)
+    await assert_messages_produced(ops_test, KAFKA_APP_B, pattern=".*.fornost", no_messages=100)


### PR DESCRIPTION
Tests an active|active deployment:

```
kafka-a <-- connect-a <-- mirrormaker-a
kafka-b <-- connect-b <-- mirrormaker-b

mirrormaker-a:source kafka-a
mirrormaker-a:target kafka-b

mirrormaker-b:source kafka-b
mirrormaker-b:target kafka-a
```