### PR TITLE
[DPE-6994] - fix: add subst+impl metadata, publish MM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,7 @@ jobs:
           - integration-mysql
           - integration-postgresql
           - integration-s3
+          - integration-mirrormaker
 
     name: ${{ matrix.tox-environments }} (K8S)
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,7 +190,11 @@ jobs:
       - name: Download plugin
         run: |
           plugin_url=$(yq -r '.links."plugin-url"[0]' build/metadata.yaml)
-          wget $plugin_url -O build/plugin.tar
+          if [ ${{ matrix.build-args.impl }} == 'mirrormaker' ]; then
+            tar cvf build/plugin.tar --files-from /dev/null
+          else
+            wget $plugin_url -O build/plugin.tar
+          fi
       - name: Register
         run: charmcraft register ${{ matrix.build-args.name }}
         continue-on-error: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,6 +97,15 @@ jobs:
             substrate: vm
             data-interface: opensearch_client
             impl: opensearch
+          # mirrormaker
+          - name: mirrormaker-connect-integrator
+            substrate: vm
+            data-interface: kafka_client
+            impl: mirrormaker
+          - name: mirrormaker-connect-k8s-integrator
+            substrate: k8s
+            data-interface: kafka_client
+            impl: mirrormaker
 
     name: '${{ matrix.build-args.name }} - ${{ matrix.platform.name }}'
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,10 +189,10 @@ jobs:
           if-no-files-found: error
       - name: Download plugin
         run: |
-          plugin_url=$(yq -r '.links."plugin-url"[0]' build/metadata.yaml)
           if [ ${{ matrix.build-args.impl }} == 'mirrormaker' ]; then
             tar cvf build/plugin.tar --files-from /dev/null
           else
+            plugin_url=$(yq -r '.links."plugin-url"[0]' build/metadata.yaml)
             wget $plugin_url -O build/plugin.tar
           fi
       - name: Register

--- a/metadata.yaml.j2
+++ b/metadata.yaml.j2
@@ -6,32 +6,27 @@ name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker 
 display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker Integrator
 summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker Integrator
 description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker Integrator charm enables the management of Apache Kafka Connect tasks to mirror and replicate topics from one Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application to another.
-
 {%- elif impl == "s3" %}
 name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator
 display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator
 summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator
 description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator charm enables the management of Apache Kafka Connect tasks to sink data from a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application to an S3-compatible storage volume.
-
 {%- elif impl == "opensearch" %}
 name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator
 display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator
 summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator
 description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator charm enables the management of Apache Kafka Connect tasks to sink data from a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application to a Charmed OpenSearch{{ "" if substrate == "vm" else " K8s" }} application.
-
 {%- elif impl == "mysql" %}
 name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator
 display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator
 summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator
 description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator charm enables the management of Apache Kafka Connect tasks to transfer data to/from a Charmed MySQL{{ "" if substrate == "vm" else " K8s" }} application and a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application over JDBC.
-
 {%- elif impl == "postgresql" %}
 name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator
 display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator
 summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator
 description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator charm enables the management of Apache Kafka Connect tasks to transfer data to/from a Charmed PostgreSQL{{ "" if substrate == "vm" else " K8s" }} application and a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application over JDBC.
-
-{%- endif % }
+{%- endif %}
 
 source: https://github.com/canonical/template-connect-integrator
 issues: https://github.com/canonical/template-connect-integrator/issues

--- a/metadata.yaml.j2
+++ b/metadata.yaml.j2
@@ -1,12 +1,41 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: {{ name }}
-display-name: Apache Kafka Connect Integrator
-description: |
-  Description
-summary: Apache Kafka Connect Integrator
+
+{%- if impl == "mirrormaker" %}
+name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker Integrator
+display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker Integrator
+summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker Integrator
+description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MirrorMaker Integrator charm enables the management of Apache Kafka Connect tasks to mirror and replicate topics from one Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application to another.
+
+{%- elif impl == "s3" %}
+name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator
+display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator
+summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator
+description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} S3 Integrator charm enables the management of Apache Kafka Connect tasks to sink data from a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application to an S3-compatible storage volume.
+
+{%- elif impl == "opensearch" %}
+name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator
+display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator
+summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator
+description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} OpenSearch Integrator charm enables the management of Apache Kafka Connect tasks to sink data from a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application to a Charmed OpenSearch{{ "" if substrate == "vm" else " K8s" }} application.
+
+{%- elif impl == "mysql" %}
+name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator
+display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator
+summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator
+description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} MySQL Integrator charm enables the management of Apache Kafka Connect tasks to transfer data to/from a Charmed MySQL{{ "" if substrate == "vm" else " K8s" }} application and a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application over JDBC.
+
+{%- elif impl == "postgresql" %}
+name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator
+display-name: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator
+summary: Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator
+description: The Apache Kafka Connect{{ "" if substrate == "vm" else " K8s" }} PostgreSQL Integrator charm enables the management of Apache Kafka Connect tasks to transfer data to/from a Charmed PostgreSQL{{ "" if substrate == "vm" else " K8s" }} application and a Charmed Apache Kafka{{ "" if substrate == "vm" else " K8s" }} application over JDBC.
+
+{%- endif % }
+
 source: https://github.com/canonical/template-connect-integrator
 issues: https://github.com/canonical/template-connect-integrator/issues
+
 links:
   plugin-url:
 {%- if impl in ("mysql", "postgresql") %}

--- a/metadata.yaml.j2
+++ b/metadata.yaml.j2
@@ -39,9 +39,6 @@ links:
     - https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/releases/download/v3.1.1/opensearch-connector-for-apache-kafka-3.1.1.tar
 {%- elif impl == "s3" %}
     - https://github.com/Aiven-Open/cloud-storage-connectors-for-apache-kafka/releases/download/v3.1.0/s3-sink-connector-for-apache-kafka-3.1.0.tar
-{%- elif impl == "mirrormaker" %}
-    - https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
-    - https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
 {%- endif %}
 
 website:

--- a/metadata.yaml.j2
+++ b/metadata.yaml.j2
@@ -39,6 +39,9 @@ links:
     - https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/releases/download/v3.1.1/opensearch-connector-for-apache-kafka-3.1.1.tar
 {%- elif impl == "s3" %}
     - https://github.com/Aiven-Open/cloud-storage-connectors-for-apache-kafka/releases/download/v3.1.0/s3-sink-connector-for-apache-kafka-3.1.0.tar
+{%- elif impl == "mirrormaker" %}
+    - https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+    - https://github.com/apache/kafka/blob/trunk/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
 {%- endif %}
 
 website:


### PR DESCRIPTION
## Changes Made
#### `fix: add substrate+impl specific metadata`
- Fixes Charmhub rendering charm name and description
- K8s + VM are now named and described with the requisite `K8s` suffixes where needed
    - Note that OS also appends `K8s` suffix, but this shouldn't run as we don't have `impl=opensearch; substrate=k8s` in the release CI 
#### `cicd: actually release mirrormaker integrator`
- Use the normal `empty.tar` command for the `connect-plugin` resource for conditionally for `impl=mirrormaker`, as probably needed for CH release