### PR TITLE
chore: update rust version

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -73,7 +73,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.87.0 # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging


### PR DESCRIPTION
This PR updates rust to 1.87 in order to fix the scheduled tests failures due to outdated rust version